### PR TITLE
Add skip-missing option to gocredits action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
   path:
     description: 'Relative path under $GITHUB_WORKSPACE to execute gocredits'
     required: false
+  skip-missing:
+    description: 'Add -skip-missing option to gocredits'
+    default: 'false'
+    required: false
 outputs:
   exitcode:
     description: 'Exit code of gocredits'
@@ -66,7 +70,8 @@ runs:
         if ('${{ inputs.path }}') {
           cd ${{ inputs.path }}
         }
-        $actual = gocredits | Out-String
+        $skipMissing = if ('${{ inputs.skip-missing }}' -eq 'true') { '-skip-missing' } else { '' }
+        $actual = gocredits $skipMissing | Out-String
         $expected = if (Test-Path '${{ inputs.credits_file }}') { Get-Content -Raw '${{ inputs.credits_file }}' } else { '' }
         if ($expected -eq $null) {
           $expected = ''
@@ -88,7 +93,11 @@ runs:
         if [[ "${{ inputs.path }}" != "" ]]; then
           cd ${{ inputs.path }}
         fi
-        diff <(gocredits) ${{ inputs.credits_file }}
+        SKIP_MISSING_OPTION=""
+        if [[ "${{ inputs.skip-missing }}" == "true" ]]; then
+          SKIP_MISSING_OPTION="-skip-missing"
+        fi
+        diff <(gocredits $SKIP_MISSING_OPTION) ${{ inputs.credits_file }}
         exitcode="$?"
         echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
     - name: Setup check gocredits output
@@ -110,7 +119,11 @@ runs:
         if [[ "${{ inputs.path }}" != "" ]]; then
           cd ${{ inputs.path }}
         fi
-        gocredits . > ${{ inputs.credits_file }}
+        SKIP_MISSING_OPTION=""
+        if [[ "${{ inputs.skip-missing }}" == "true" ]]; then
+          SKIP_MISSING_OPTION="-skip-missing"
+        fi
+        gocredits $SKIP_MISSING_OPTION . > ${{ inputs.credits_file }}
     - name: Commit gocredits file
       if: inputs.mode == 'update'
       uses: suzuki-shunsuke/commit-action@cc96d3a3fd959d05e9b79ca395eb30b835aeba24 # v0.0.7


### PR DESCRIPTION
This pull request introduces a new optional input parameter, `skip-missing`, to the `action.yml` file, allowing users to include the `-skip-missing` option when running the `gocredits` command. The changes ensure that this parameter is correctly handled across different execution environments (PowerShell and Bash).

### Additions to `action.yml`:

* **New Input Parameter**:
  - Added `skip-missing` as an optional input with a default value of `false`. This parameter enables the `-skip-missing` option for `gocredits`. (`[action.ymlR31-R34](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R31-R34)`)

### Modifications to `runs:`:

* **PowerShell Script**:
  - Added logic to conditionally include the `-skip-missing` option in the `gocredits` command based on the value of `skip-missing`. (`[action.ymlL69-R74](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L69-R74)`)

* **Bash Scripts**:
  - Updated the `diff` command to include the `-skip-missing` option when `skip-missing` is set to `true`. (`[action.ymlL91-R100](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L91-R100)`)
  - Updated the `gocredits` command for generating credits files to include the `-skip-missing` option when applicable. (`[action.ymlL113-R126](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L113-R126)`)